### PR TITLE
Spacer components.

### DIFF
--- a/Mjml.Net/AttributeType.cs
+++ b/Mjml.Net/AttributeType.cs
@@ -4,6 +4,7 @@
     {
         Color,
         Pixels,
+        PixelsOrPercent,
         String
     }
 }

--- a/Mjml.Net/Components/Body/BodyComponentBase.cs
+++ b/Mjml.Net/Components/Body/BodyComponentBase.cs
@@ -8,6 +8,14 @@
                 "mj-body"
             };
 
+        public virtual AllowedAttributes? AllowedAttributes => null;
+
+        public virtual Attributes? DefaultAttributes => null;
+
+        public virtual bool SelfClosed => false;
+
+        public virtual bool NeedsContent => false;
+
         public abstract string ComponentName { get; }
 
         public abstract void Render(IHtmlRenderer renderer, INode node);

--- a/Mjml.Net/Components/Body/SpacerComponent.cs
+++ b/Mjml.Net/Components/Body/SpacerComponent.cs
@@ -1,0 +1,43 @@
+﻿namespace Mjml.Net.Components.Body
+{
+    public sealed class SpacerComponent : BodyComponentBase
+    {
+        public override string ComponentName => "mj-spacer";
+
+        public override AllowedAttributes? AllowedAttributes { get; } =
+            new AllowedAttributes
+            {
+                ["border"] = AttributeType.String,
+                ["border-bottom"] = AttributeType.String,
+                ["border-left"] = AttributeType.String,
+                ["border-right"] = AttributeType.String,
+                ["border-top"] = AttributeType.String,
+                ["container-background-color"] = AttributeType.Color,
+                ["height"] = AttributeType.PixelsOrPercent,
+                ["padding"] = AttributeType.PixelsOrPercent,
+                ["padding-bottom"] = AttributeType.PixelsOrPercent,
+                ["padding-left"] = AttributeType.PixelsOrPercent,
+                ["padding-right"] = AttributeType.PixelsOrPercent,
+                ["padding-top"] = AttributeType.PixelsOrPercent,
+            };
+
+        public override Attributes? DefaultAttributes { get; } =
+            new Attributes
+            {
+                ["height"] = "20px"
+            };
+
+        public override void Render(IHtmlRenderer renderer, INode node)
+        {
+            var height = node.GetAttribute("height");
+
+            renderer.ElementStart("div")
+                .Style("height", height)
+                .Style("line-height", height);
+
+            renderer.Content("&#8202;");
+
+            renderer.ElementEnd("div");
+        }
+    }
+}

--- a/Mjml.Net/Components/Head/HeadComponentBase.cs
+++ b/Mjml.Net/Components/Head/HeadComponentBase.cs
@@ -8,6 +8,14 @@
                 "mj-head"
             };
 
+        public virtual AllowedAttributes? AllowedAttributes => null;
+
+        public virtual Attributes? DefaultAttributes => null;
+
+        public virtual bool SelfClosed => false;
+
+        public virtual bool NeedsContent => false;
+
         public abstract string ComponentName { get; }
 
         public abstract void Render(IHtmlRenderer renderer, INode node);

--- a/Mjml.Net/Helpers/Breakpoint.cs
+++ b/Mjml.Net/Helpers/Breakpoint.cs
@@ -1,6 +1,8 @@
 ﻿namespace Mjml.Net.Helpers
 {
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
     public sealed record Breakpoint(string Value)
+#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     {
         public static readonly Breakpoint Default = new Breakpoint("480px");
     }

--- a/Mjml.Net/Helpers/Style.cs
+++ b/Mjml.Net/Helpers/Style.cs
@@ -1,6 +1,8 @@
 ﻿namespace Mjml.Net.Helpers
 {
+#pragma warning disable SA1313 // Parameter names should begin with lower-case letter
     public sealed record Style(string Value, bool Inline = false)
+#pragma warning restore SA1313 // Parameter names should begin with lower-case letter
     {
     }
 

--- a/Mjml.Net/MjmlRenderContext.Rendering.cs
+++ b/Mjml.Net/MjmlRenderContext.Rendering.cs
@@ -324,20 +324,12 @@ namespace Mjml.Net
             {
                 buffers.Current.Append(" style=\"");
 
-                var index = 0;
                 foreach (var (key, value) in currentRenderStyles)
                 {
                     buffers.Current.Append(key);
                     buffers.Current.Append(':');
-                    buffers.Current.Append(' ');
                     buffers.Current.Append(value);
-
-                    if (index < currentRenderStyles.Count - 1)
-                    {
-                        buffers.Current.Append("; ");
-                    }
-
-                    index++;
+                    buffers.Current.Append(';');
                 }
 
                 buffers.Current.Append('"');

--- a/Mjml.Net/MjmlRenderContext.cs
+++ b/Mjml.Net/MjmlRenderContext.cs
@@ -153,7 +153,9 @@ namespace Mjml.Net
                 }
             }
 
-            if (currentComponent?.DefaultAttributes?.TryGetValue(name, out attribute) == true)
+            var defaultAttributes = currentComponent?.DefaultAttributes;
+
+            if (defaultAttributes != null && defaultAttributes.TryGetValue(name, out attribute))
             {
                 return attribute;
             }

--- a/Mjml.Net/MjmlRenderer.cs
+++ b/Mjml.Net/MjmlRenderer.cs
@@ -23,6 +23,7 @@ namespace Mjml.Net
             Add(new PreviewComponent());
             Add(new RawComponent());
             Add(new RootComponent());
+            Add(new SpacerComponent());
             Add(new StyleComponent());
             Add(new TitleComponent());
 

--- a/Tests/Properties/Resources.Designer.cs
+++ b/Tests/Properties/Resources.Designer.cs
@@ -133,6 +133,28 @@ namespace Tests.Properties {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to &lt;div style=&quot;height:20px;line-height:20px;&quot;&gt;
+        ///  &amp;#8202;
+        ///&lt;/div&gt;.
+        /// </summary>
+        internal static string Spacer {
+            get {
+                return ResourceManager.GetString("Spacer", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to &lt;div style=&quot;height:100px;line-height:100px;&quot;&gt;
+        ///  &amp;#8202;
+        ///&lt;/div&gt;.
+        /// </summary>
+        internal static string SpacerWithHeight {
+            get {
+                return ResourceManager.GetString("SpacerWithHeight", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to &lt;style type=&quot;text/css&quot;&gt;
         ///  .red-text div {
         ///    color: red !important;

--- a/Tests/Properties/Resources.resx
+++ b/Tests/Properties/Resources.resx
@@ -217,6 +217,16 @@
   Hello MJML
 &lt;/div&gt;</value>
   </data>
+  <data name="Spacer" xml:space="preserve">
+    <value>&lt;div style="height:20px;line-height:20px;"&gt;
+  &amp;#8202;
+&lt;/div&gt;</value>
+  </data>
+  <data name="SpacerWithHeight" xml:space="preserve">
+    <value>&lt;div style="height:100px;line-height:100px;"&gt;
+  &amp;#8202;
+&lt;/div&gt;</value>
+  </data>
   <data name="Style" xml:space="preserve">
     <value>&lt;style type="text/css"&gt;
   .red-text div {

--- a/Tests/SpacerTests.cs
+++ b/Tests/SpacerTests.cs
@@ -4,21 +4,15 @@ using Xunit;
 
 namespace Tests
 {
-    public class StyleTests
+    public class SpacerTests
     {
         [Fact]
-        public void Should_render_style()
+        public void Should_render_spacer()
         {
             var source = @"
 <mjml>
-  <mj-head>
-    <mj-style>
-      .red-text div {
-        color: red !important;
-      }
-    </mj-style>
-  </mj-head>
   <mj-body>
+    <mj-spacer />
   </mj-body>
 </mjml>
 ";
@@ -28,7 +22,7 @@ namespace Tests
                 Beautify = true,
             });
 
-            TestHelpers.TrimmedContains(Resources.Style, result);
+            TestHelpers.TrimmedContains(Resources.Spacer, result);
         }
 
         [Fact]
@@ -36,14 +30,8 @@ namespace Tests
         {
             var source = @"
 <mjml>
-  <mj-head>
-    <mj-style inline=""inline"">
-      .red-text div {
-        color: red !important;
-      }
-    </mj-style>
-  </mj-head>
   <mj-body>
+    <mj-spacer height=""100px"" />
   </mj-body>
 </mjml>
 ";
@@ -53,7 +41,7 @@ namespace Tests
                 Beautify = true,
             });
 
-            TestHelpers.TrimmedContains(Resources.Style, result);
+            TestHelpers.TrimmedContains(Resources.SpacerWithHeight, result);
         }
     }
 }


### PR DESCRIPTION
Closes #12 

Also fixes a few minor issues in the renderer. Perhaps we should remove all whitespaces when we compare in tests.